### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ WebApp: https://weather-station-iot-170004.firebaseapp.com
 * Create PubSub subscription for device data:
     * `gcloud beta pubsub subscriptions create --topic telemetry-topic telemetry-subscription`
 * Create device registry:
-    * `gcloud beta iot registries create weather-station-registry --region us-central1 --event-pubsub-topic=telemetry-topic`
+    * `gcloud beta iot registries create weather-station-registry --region us-central1 -event-notification-config=topic=projects/YOUR_PROJECT_NAME/topics/telemetry-topic`
 
 ### Upload firmware with Mongoose OS Tools
 


### PR DESCRIPTION
```WARNING: Flag --event-pubsub-topic is deprecated. Use --event-notification-config instead.```

The ```--event-pubsub-topic``` parameter has been replaced by the new version of Cloud SDK's parameters.

https://groups.google.com/forum/#!topic/google-cloud-sdk-announce/OANALtpajpY